### PR TITLE
1ドットの画像を追加した

### DIFF
--- a/data/image/black.png
+++ b/data/image/black.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03d2bdba0ebc720830ad918e36127197b30fb870bc94d69828f70927b3ee0540
+size 82

--- a/data/image/toumei.png
+++ b/data/image/toumei.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e68f1b72ba7a0d8ef2180f98c96ec64cd9084143aab759f7a7f3b6b9cbe1e2b3
+size 95

--- a/data/image/white.png
+++ b/data/image/white.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:297611cdbf82d972cda60670bf68b3bcfebc10a30dae8c2abca947e163374d62
+size 82


### PR DESCRIPTION
### 変更内容
黒、白、透明の1ドットの画像を追加しました。

### 目的
背景やキャラクターのベースに使用してください。
width、heightプロパティで引き伸ばすことで好きな大きさにできます。

例えば、背景を黒くするときは、
`[bg storage="../image/black.png"]`

キャラクターのベースにするときは、
`[chara_new name="kyon" storage="../image/toumei.png" width="515" height="727" color="0xff0000" jname="キョン"]`

のように使用してください。